### PR TITLE
Fix Zabbixapi version to 2.0.0 

### DIFF
--- a/bin/post_install
+++ b/bin/post_install
@@ -50,6 +50,6 @@ echo "update ${OPENSHIFT_APP_NAME}.users set passwd=md5('$OPENSHIFT_ZABBIX_PASSW
 touch $OPENSHIFT_ZABBIX_DIR/etc/.configured
 $OPENSHIFT_ZABBIX_DIR/bin/control start
 
-oo-exec-ruby gem install zabbixapi
+oo-exec-ruby gem install zabbixapi -v 2.0.0
 
 $OPENSHIFT_ZABBIX_DIR/usr/bin/zabbix-import-template $OPENSHIFT_ZABBIX_DIR/versions/shared/configuration/etc/templates/zbx_gear_templates.xml


### PR DESCRIPTION
This is my workaround for https://github.com/a13m/openshift-zabbix-cartridge/issues/4 

I had to depoy my own CDK with this code (I'm using Openshift Entreprise)
