### PR TITLE
Force "no-proxy" on zabbix import template action

### DIFF
--- a/usr/bin/zabbix-add-host.rb
+++ b/usr/bin/zabbix-add-host.rb
@@ -20,7 +20,7 @@ zbx.hosts.create(
       :useip => 0
     }
   ],
-  :groups => [ :groupid => zbx.hostgroups.get_id(:name => "gears") ],
-  :templates => [ :templateid => zbx.templates.get_id(:host => "Template OpenShift gear") ]
+  :groups => [ :groupid => zbx.hostgroups.get_id(:name => "OpenShift Gears") ],
+  :templates => [ :templateid => zbx.templates.get_id(:host => "Template OpenShift Gear") ]
 )
 

--- a/usr/bin/zabbix-import-template.py
+++ b/usr/bin/zabbix-import-template.py
@@ -89,7 +89,9 @@ class ZabbixAPI(object):
   def printResult(self, var):
     data = json.dumps(var)
     request = urllib2.Request(self.url, data, {"Content-Type" : "application/json"})
-    response = urllib2.urlopen(request)
+    proxy_handler = urllib2.ProxyHandler({})
+    opener = urllib2.build_opener(proxy_handler)
+    response = opener.open(request)
     return json.load(response)
 
 if __name__ == "__main__":

--- a/versions/shared/configuration/etc/templates/zbx_gear_templates.xml
+++ b/versions/shared/configuration/etc/templates/zbx_gear_templates.xml
@@ -1392,7 +1392,7 @@
             <macros/>
             <templates>
                 <template>
-                    <name>Template OpenShift node</name>
+                    <name>Template OpenShift Node</name>
                 </template>
             </templates>
             <screens/>


### PR DESCRIPTION
This commit allow zabbix-import-template script to send request without using the default HTTP_PROXY.

Before this commit the script used the default HTTP_PROXY env variable if declared.
As the cartridge is colocalized with zabbix rest api, this script use a local address to contact zabbix and if you use a http proxy then requests will fail.
