### PR TITLE
Fix template and group names

### DIFF
--- a/usr/bin/zabbix-add-host.rb
+++ b/usr/bin/zabbix-add-host.rb
@@ -20,7 +20,7 @@ zbx.hosts.create(
       :useip => 0
     }
   ],
-  :groups => [ :groupid => zbx.hostgroups.get_id(:name => "gears") ],
-  :templates => [ :templateid => zbx.templates.get_id(:host => "Template OpenShift gear") ]
+  :groups => [ :groupid => zbx.hostgroups.get_id(:name => "OpenShift Gears") ],
+  :templates => [ :templateid => zbx.templates.get_id(:host => "Template OpenShift Gear") ]
 )
 

--- a/versions/shared/configuration/etc/templates/zbx_gear_templates.xml
+++ b/versions/shared/configuration/etc/templates/zbx_gear_templates.xml
@@ -1392,7 +1392,7 @@
             <macros/>
             <templates>
                 <template>
-                    <name>Template OpenShift node</name>
+                    <name>Template OpenShift Node</name>
                 </template>
             </templates>
             <screens/>


### PR DESCRIPTION
It seems that after/with this commit : https://github.com/a13m/openshift-zabbix-cartridge/commit/956c50b33467659120c5ad7ecc9d134c6fe1a214 names and groups should have been modified on zabbix-add-host script.
